### PR TITLE
Fixed post status fields being lowercase

### DIFF
--- a/resources/js/Pages/Shared/Compose.vue
+++ b/resources/js/Pages/Shared/Compose.vue
@@ -78,9 +78,9 @@
                                             <select v-model="form.status" name="status" id="status"
                                                 class="select select-bordered w-full max-w-xs">
                                                 <option disabled value="">Status</option>
-                                                <option value="public" selected>Public</option>
-                                                <option value="unlisted">Unlisted</option>
-                                                <option value="private">Private</option>
+                                                <option value="Public" selected>Public</option>
+                                                <option value="Unlisted">Unlisted</option>
+                                                <option value="Private">Private</option>
                                             </select>
                                         </div>
 
@@ -123,7 +123,7 @@ let form = useForm({
     description: "",
     video: "",
     nsfw: "",
-    status: "public",
+    status: "Public",
 })
 
 let submit = () => {

--- a/resources/js/Pages/Shared/Post.vue
+++ b/resources/js/Pages/Shared/Post.vue
@@ -2,7 +2,7 @@
     <div>
         <!-- Put this part before </body> tag -->
         <form @submit.prevent="submit">
-             
+
             <h3 class="font-bold text-lg dark:text-white">Upload a video {{$page.props.user.name}}</h3>
             <div class="py-4">
                 <div class="form-control py-2">
@@ -47,7 +47,7 @@
                 <div class="justify-start">
                     <div class="form-control">
                         <label class="label cursor-pointer mt-1">
-                            <span class="label-text dark:text-white mr-2">NSFW?</span> 
+                            <span class="label-text dark:text-white mr-2">NSFW?</span>
                             <input v-model="form.nsfw" type="checkbox" name="nsfw" id="nsfw" class="checkbox" />
                         </label>
                     </div>
@@ -55,9 +55,9 @@
                 <div class="justify-start">
                     <select v-model="form.status" name="status" id="status" class="select select-bordered w-full max-w-xs">
                         <option disabled value="">Status</option>
-                        <option value="public" selected>Public</option>
-                        <option value="unlisted">Unlisted</option>
-                        <option value="private">Private</option>
+                        <option value="Public" selected>Public</option>
+                        <option value="Unlisted">Unlisted</option>
+                        <option value="Private">Private</option>
                     </select>
                 </div>
 
@@ -85,7 +85,7 @@ let form = useForm({
   description: "",
   video: "",
   nsfw: "",
-  status:   "public",
+  status:   "Public",
 });
 
 let submit = () => {


### PR DESCRIPTION
There is the following constraint on the posts table
`
alter table public.posts add constraint posts_status_check check (((status)::text = any ((array['Public'::character varying,
'Unlisted'::character varying,
'Private'::character varying])::text[])));
`

Because of the values in these select fields being lowercase, the constraint fails when these values get used as the 'status' column in the insert statement.

I am not sure about how(and from where) this application is deployed, but on goldfish.social these values are uppercase and posting works.