### PR TITLE
Fixed route name collision on post deletes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,7 @@ Route::middleware(['auth:sanctum', config('jetstream.auth_session'), 'verified',
     Route::group(['middleware' => 'admin'], function () {
         Route::get('/admin/users', [AdminController::class, 'users'])->name('admin.users');
         Route::get('/admin/posts', [AdminController::class, 'posts'])->name('admin.posts');
-        Route::delete('/posts/{post}/delete', [AdminController::class, 'deletePost'])->name('admin.post.destroy');
-        Route::delete('/@{user:id}/delete', [AdminController::class, 'deleteUser'])->name('admin.user.destroy');
+        Route::delete('/admin/posts/{post}/delete', [AdminController::class, 'deletePost'])->name('admin.post.destroy');
+        Route::delete('/admin/@{user:id}/delete', [AdminController::class, 'deleteUser'])->name('admin.user.destroy');
     });
 });


### PR DESCRIPTION
Due to both the admin post delete and the user post delete being /posts/{post}/delete, there was a collision. [this issue](https://github.com/Goldfish-Social/Goldfish/issues/27#issue-1368625756) reported this collision.

This fix also adds /admin to another admin route that doesnt have it. This is not fixing any bug, but just making things consistent. There should be no side effects from this change, as everything that references these two routes references them by their name. 