### PR TITLE
changing the form.errors.name

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -148,12 +148,12 @@ const clearPhotoFileInput = () => {
                 <JetLabel for="about" value="About" />
                 <textarea
                 v-model="form.about"
-                class="textarea textarea-primary w-full dark:bg-gray-900 dark:text-white" 
+                class="textarea textarea-primary w-full dark:bg-gray-900 dark:text-white"
                 rows="4"
                 >
                 </textarea>
-                
-                <JetInputError :message="form.errors.name" class="mt-2" />
+
+                <JetInputError :message="form.errors.about" class="mt-2" />
             </div>
 
             <!-- Website -->


### PR DESCRIPTION
I think this might fix this small issue. 

![image](https://user-images.githubusercontent.com/48828440/196172955-b7e7030f-e6ed-4542-b641-c10eff554844.png)

Trying to enter an empty name also marks the 'About' field as the same name error. 