### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/lang/pt_BR/auth.php
+++ b/lang/pt_BR/auth.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'Essas credenciais não correspondem aos nossos registros.',
+    'password' => 'A senha fornecida está incorreta.',
+    'throttle' => 'Muitas tentativas de login. Por favor, tente novamente em :seconds segundos.',
+
+];

--- a/lang/pt_BR/messages.php
+++ b/lang/pt_BR/messages.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+
+    'login' => 'Login',
+    'register' => 'Registrar',
+
+];

--- a/lang/pt_BR/pagination.php
+++ b/lang/pt_BR/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Anterior',
+    'next' => 'Próximo &raquo;',
+
+];

--- a/lang/pt_BR/passwords.php
+++ b/lang/pt_BR/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'Sua senha foi alterada!',
+    'sent' => 'Enviamos o seu link de redefinição de senha por e-mail!',
+    'throttled' => 'Aguarde antes de tentar novamente.',
+    'token' => 'Este token de redefinição de senha é inválido.',
+    'user' => "Não conseguimos encontrar um usuários com esse endereço de e-mail.",
+
+];

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -1,0 +1,170 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => 'O :attribute deve ser aceito.',
+    'accepted_if' => 'O :attribute deve ser aceito quando :other for :value.',
+    'active_url' => 'O :attribute não é um URL válido.',
+    'after' => 'O :attribute deve ser uma data após :date.',
+    'after_or_equal' => 'O :attribute deve ser uma data posterior ou igual a :date.',
+    'alpha' => 'O :attribute deve conter apenas letras.',
+    'alpha_dash' => 'O :attribute deve conter apenas letras, números, traços e sublinhados.',
+    'alpha_num' => 'O :attribute deve conter apenas letras e números.',
+    'array' => 'O :attribute deve ser um array.',
+    'before' => 'O :attribute deve ser uma data anterior a :date.',
+    'before_or_equal' => 'O :attribute deve ser uma data anterior ou igual a :date.',
+    'between' => [
+        'array' => 'O :attribute deve ter entre :min e :max itens.',
+        'file' => 'O :attribute deve estar entre :min e :max kilobytes.',
+        'numeric' => 'O :attribute deve estar entre :min e :max.',
+        'string' => 'O :attribute deve estar entre :min e :max caracteres.',
+    ],
+    'boolean' => 'O campo :attribute deve ser verdadeiro ou falso.',
+    'confirmed' => 'A confirmação :attribute não corresponde.',
+    'current_password' => 'A senha está incorreta.',
+    'date' => 'O :attribute não é uma data válida.',
+    'date_equals' => 'O :attribute deve ser uma data igual a :date.',
+    'date_format' => 'O :attribute não corresponde ao formato :format.',
+    'declined' => 'O :attribute deve ser recusado.',
+    'declined_if' => 'O :attribute deve ser recusado quando :other for :value.',
+    'different' => 'O :attribute e :other devem ser diferentes.',
+    'digits' => 'O :attribute precisa ter :digits dígitos.',
+    'digits_between' => 'O :attribute deve ter entre :min e :max dígitos.',
+    'dimensions' => 'O :attribute tem dimensões de imagem inválidas.',
+    'distinct' => 'O campo :attribute tem um valor duplicado.',
+    'doesnt_start_with' => 'O :attribute não pode começar com um dos seguintes: :values.',
+    'email' => 'O :attribute deve ser um endereço de e-mail válido.',
+    'ends_with' => 'O :attribute deve terminar com um dos seguintes: :values.',
+    'enum' => 'O :attribute selecionado é inválido.',
+    'exists' => 'O :attribute selecionado é inválido.',
+    'file' => 'O :attribute deve ser um arquivo.',
+    'filled' => 'O campo :attribute deve ter um valor.',
+    'gt' => [
+        'array' => 'O :attribute deve ter mais de :value itens.',
+        'file' => 'O :attribute deve ser maior que :value kilobytes.',
+        'numeric' => 'O :attribute deve ser maior que :value.',
+        'string' => 'O :attribute deve ser maior que :value caracteres.',
+    ],
+    'gte' => [
+        'array' => 'O :attribute deve ter :value itens ou mais.',
+        'file' => 'O :attribute deve ser maior ou igual a :value kilobytes.',
+        'numeric' => 'O :attribute deve ser maior ou igual a :value.',
+        'string' => 'O :attribute deve ser maior ou igual a :value caracteres.',
+    ],
+    'image' => 'O :attribute deve ser uma imagem.',
+    'in' => 'O :attribute selecionado é inválido.',
+    'in_array' => 'O campo :attribute não existe em :other.',
+    'integer' => 'O :attribute deve ser um número inteiro.',
+    'ip' => 'O :attribute deve ser um endereço IP válido.',
+    'ipv4' => 'O :attribute deve ser um endereço IPv4 válido.',
+    'ipv6' => 'O :attribute deve ser um endereço IPv6 válido.',
+    'json' => 'O :attribute deve ser uma string JSON válida.',
+    'lt' => [
+        'array' => 'O :attribute precisa ter menos que :value itens.',
+        'file' => 'O :attribute deve ter menos que :value kilobytes.',
+        'numeric' => 'O :attribute deve ser menos que :value.',
+        'string' => 'O :attribute deve ter menos que :value caracteres.',
+    ],
+    'lte' => [
+        'array' => 'O :attribute não deve ter mais do que :value itens.',
+        'file' => 'O :attribute deve ser menor ou igual a :value kilobytes.',
+        'numeric' => 'O :attribute deve ser menor ou igual a :value.',
+        'string' => 'O :attribute deve ser menor ou igual a :value caracteres.',
+    ],
+    'mac_address' => 'O :attribute deve ser um endereço MAC válido.',
+    'max' => [
+        'array' => 'O :attribute não deve ter mais do que :max itens.',
+        'file' => 'O :attribute não deve ser maior que :max kilobytes.',
+        'numeric' => 'O :attribute não deve ser maior que :max.',
+        'string' => 'O :attribute não deve ser maior que :max caracteres.',
+    ],
+    'mimes' => 'O :attribute deve ser um arquivo do tipo: :values.',
+    'mimetypes' => 'O :attribute deve ser um arquivo do tipo: :values.',
+    'min' => [
+        'array' => 'O :attribute deve ter pelo menos :min itens.',
+        'file' => 'O :attribute deve ter pelo menos :min kilobytes.',
+        'numeric' => 'O :attribute deve ser pelo menos :min.',
+        'string' => 'O :attribute deve ter pelo menos :min caracteres.',
+    ],
+    'multiple_of' => 'O :attribute deve ser um múltiplo de :value.',
+    'not_in' => 'O :attribute selecionado é inválido.',
+    'not_regex' => 'O formato :attribute é inválido.',
+    'numeric' => 'O :attribute deve ser um número.',
+    'password' => [
+        'letters' => 'O :attribute deve conter pelo menos uma letra.',
+        'mixed' => 'O :attribute deve conter pelo menos uma letra maiúscula e uma minúscula.',
+        'numbers' => 'O :attribute deve conter pelo menos um número.',
+        'symbols' => 'O :attribute deve conter pelo menos um símbolo.',
+        'uncompromised' => 'O dado :attribute apareceu em um vazamento de dados. Escolha um :attribute diferente.',
+    ],
+    'present' => 'O campo :attribute deve estar presente.',
+    'prohibited' => 'O campo :attribute é proibido.',
+    'prohibited_if' => 'O campo :attribute é proibido quando :other é :value.',
+    'prohibited_unless' => 'O campo :attribute é proibido a menos que :other esteja em :values.',
+    'prohibits' => 'O campo :attribute proíbe :other de estar presente.',
+    'regex' => 'O formato :attribute é inválido.',
+    'required' => 'O campo :attribute é obrigatório.',
+    'required_array_keys' => 'O campo :attribute deve conter entradas para: :values.',
+    'required_if' => 'O campo :attribute é obrigatório quando :other é :value.',
+    'required_unless' => 'O campo :attribute é obrigatório, a menos que :other esteja em :values.',
+    'required_with' => 'O campo :attribute é obrigatório quando :values está presente.',
+    'required_with_all' => 'O campo :attribute é obrigatório quando :values estão presentes.',
+    'required_without' => 'O campo :attribute é obrigatório quando :values não está presente.',
+    'required_without_all' => 'O campo :attribute é obrigatório quando nenhum dos :values está presente.',
+    'same' => 'O :attribute e :other devem corresponder.',
+    'size' => [
+        'array' => 'O :attribute deve conter :size itens.',
+        'file' => 'O :attribute deve ter :size kilobytes.',
+        'numeric' => 'O :attribute deve ser :size.',
+        'string' => 'O :attribute deve ter :size caracteres.',
+    ],
+    'starts_with' => 'O :attribute deve começar com um dos seguintes: :values.',
+    'string' => 'O :attribute deve ser uma string.',
+    'timezone' => 'O :attribute deve ser um fuso horário válido.',
+    'unique' => 'O :attribute já foi usado.',
+    'uploaded' => 'O :attribute falhou ao carregar.',
+    'url' => 'O :attribute deve ser um URL válido.',
+    'uuid' => 'O :attribute deve ser um UUID válido.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [],
+
+];


### PR DESCRIPTION
If you prefer I can change the folder name to 'pt' following the actual conventions, but I would argue that people from Portugal and other lusitanians countries might want to use it.